### PR TITLE
Escape single quotes(') and right single quotation mark(’) in the file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,17 +23,19 @@ function throwError (customLogger, message, error) {
   }
 }
 
-function generateCommands (filePaths, customLogger) {
+function generateCommands(filePaths, customLogger) {
   const commands = [];
 
   for (let filePath of filePaths) {
     const normalizedFile = normalizeFile(filePath, customLogger);
     if (normalizedFile) {
+      // Escape single quotes in the file path
+      const safeFilePath = normalizedFile.replace(/'/g, "''");
       const command = [
-        '(New-Object -COM WScript.Shell).CreateShortcut(',
-        filePath,
-        ');'
-      ].join('\'');
+        '(New-Object -COM WScript.Shell).CreateShortcut(\'',
+        safeFilePath,
+        '\');'
+      ].join('');
       commands.push(command);
     }
   }

--- a/index.js
+++ b/index.js
@@ -23,17 +23,17 @@ function throwError (customLogger, message, error) {
   }
 }
 
-function generateCommands(filePaths, customLogger) {
+function generateCommands (filePaths, customLogger) {
   const commands = [];
 
   for (let filePath of filePaths) {
     const normalizedFile = normalizeFile(filePath, customLogger);
     if (normalizedFile) {
-      // Escape single quotes and right single quoation marks(’) in the file path
+      // Escape (') and (’) in the file path for PowerShell syntax
       const safeFilePath = normalizedFile
         .replace(/'/g, "''")
         .replace(/’/g, "’’");
-        
+
       const command = [
         '(New-Object -COM WScript.Shell).CreateShortcut(\'',
         safeFilePath,

--- a/index.js
+++ b/index.js
@@ -29,8 +29,11 @@ function generateCommands(filePaths, customLogger) {
   for (let filePath of filePaths) {
     const normalizedFile = normalizeFile(filePath, customLogger);
     if (normalizedFile) {
-      // Escape single quotes in the file path
-      const safeFilePath = normalizedFile.replace(/'/g, "''");
+      // Escape single quotes and right single quoation marks(’) in the file path
+      const safeFilePath = normalizedFile
+        .replace(/'/g, "''")
+        .replace(/’/g, "’’");
+        
       const command = [
         '(New-Object -COM WScript.Shell).CreateShortcut(\'',
         safeFilePath,


### PR DESCRIPTION
## Overview
This Pull Request addresses an issue where file paths containing `single quotes (')` and `right single quotation mark(’ == u+2019)` cause errors in the `getWindowsShortcutProperties` function.

## Problem Description
The `generateCommands` function in the `get-windows-shortcut-properties` package constructs a PowerShell command using file paths. If a file path includes single quotes or (’), it breaks the command syntax in PowerShell, leading to execution failures.

## Solution
I have updated the `generateCommands` function to escape single quotes in file paths. This is accomplished by replacing each single quote or (’) in the file path with two single quotes ('') or (’’), for Powershell syntax.

